### PR TITLE
fix: marquee-content와 archive-bg-grid의 opacity를 올려 잘보이도록 조정한다.

### DIFF
--- a/projects/style/style.css
+++ b/projects/style/style.css
@@ -582,8 +582,10 @@
     top: -100%;
     left: -100%;
     background-image:
-        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+        /* linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px), */
+        linear-gradient(rgba(255, 255, 255, 0.12) 1px, transparent 1px),
+        /* linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px); */
+        linear-gradient(90deg, rgba(255, 255, 255, 0.12) 1px, transparent 1px);
     background-size: 40px 40px;
     transform: rotate(-15deg);
     pointer-events: none;
@@ -593,8 +595,10 @@
 
 .exit-banner:hover .archive-bg-grid {
     background-image:
-        linear-gradient(rgba(255, 107, 107, 0.1) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 107, 107, 0.1) 1px, transparent 1px);
+        /* linear-gradient(rgba(255, 107, 107, 0.1) 1px, transparent 1px), */
+        linear-gradient(rgba(255, 107, 107, 0.3) 1px, transparent 1px),
+        /* linear-gradient(90deg, rgba(255, 107, 107, 0.1) 1px, transparent 1px); */
+        linear-gradient(90deg, rgba(255, 107, 107, 0.3) 1px, transparent 1px);
 }
 
 .exit-banner .archive-content {

--- a/projects/style/style.css
+++ b/projects/style/style.css
@@ -35,7 +35,8 @@
     font-family: 'Silkscreen', cursive;
     font-size: 2.5rem;
     white-space: nowrap;
-    color: rgba(255, 255, 255, 0.15);
+    /* color: rgba(255, 255, 255, 0.15 ); */
+    color: rgba(255, 255, 255, 0.3 );
     /* color: rgba(255, 255, 255, 1); */
     padding: 15px 40px;
     line-height: 1;

--- a/style/style.css
+++ b/style/style.css
@@ -516,8 +516,10 @@ a {
     top: -100%;
     left: -100%;
     background-image:
-        linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px);
+        /* linear-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px), */
+        linear-gradient(rgba(255, 255, 255, 0.12) 1px, transparent 1px),
+        /* linear-gradient(90deg, rgba(255, 255, 255, 0.04) 1px, transparent 1px); */
+        linear-gradient(90deg, rgba(255, 255, 255, 0.12) 1px, transparent 1px);
     background-size: 40px 40px;
     transform: rotate(-15deg);
     pointer-events: none;
@@ -527,8 +529,10 @@ a {
 
 .archive-banner:hover .archive-bg-grid {
     background-image:
-        linear-gradient(rgba(255, 107, 107, 0.15) 1px, transparent 1px),
-        linear-gradient(90deg, rgba(255, 107, 107, 0.15) 1px, transparent 1px);
+        /* linear-gradient(rgba(255, 107, 107, 0.15) 1px, transparent 1px), */
+        linear-gradient(rgba(255, 107, 107, 0.3) 1px, transparent 1px),
+        /* linear-gradient(90deg, rgba(255, 107, 107, 0.15) 1px, transparent 1px); */
+        linear-gradient(90deg, rgba(255, 107, 107, 0.3) 1px, transparent 1px);
 }
 
 .archive-content {


### PR DESCRIPTION
### marquee-content
color rbga 중 a의 값을 `0.15` => `0.3`으로 2배 올린다.

### archive-bg-grid
linear-gradient rbga 중 a 값을 `0.04` => `0.12`로 3배 올린다.
호버 색상은 `0.15` => `0.3`으로 2배 올린다.