### PR TITLE
번역 로직을 개선한다

### DIFF
--- a/index.html
+++ b/index.html
@@ -191,12 +191,14 @@
                 title="DEVFEST INCHEON 2025">
                 <div class="gallery-item reveal-card dark-mode">
                     <img src="assets/moment/moment1.jpg"
-                        alt="2025년 12월 6일. DEVFEST INCHEON 2025 행사에서 '2026년: LLM 다음의 이야기' 세션을 기록한 사진">
+                        alt="2025년 12월 6일. DEVFEST INCHEON 2025 행사에서 '2026년: LLM 다음의 이야기' 세션을 기록한 사진"
+                        data-translate-alt="galleryAlt1">
                 </div>
             </a>
             <a href="https://aiseoul2026.com/kr/" target="_blank" rel="noopener noreferrer" title="AI SEOUL 2026">
                 <div class="gallery-item reveal-card delay-100">
-                    <img src="assets/moment/moment2.jpg" alt="2026년 1월 30일. AI SEOUL 2026 행사에 갔다온 걸 기록한 사진 ">
+                    <img src="assets/moment/moment2.jpg" alt="2026년 1월 30일. AI SEOUL 2026 행사에 갔다온 걸 기록한 사진 "
+                        data-translate-alt="galleryAlt2">
                 </div>
             </a>
         </div>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,8 @@
         <!-- <button>
             <div class="actions" translate="no">YeongGyu1110</div>
         </button> -->
-        <a href="https://github.com/yeonggyu1110" target="_blank" rel="noopener noreferrer" class="actions">
+        <a href="https://github.com/yeonggyu1110" target="_blank" rel="noopener noreferrer" class="actions"
+            translate="no">
             GITHUB <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none">
                 <path d="M7 17L17 7M17 7H7M17 7V17" />
             </svg>
@@ -83,7 +84,7 @@
     <section class="section-profile">
         <div class="profile-frame reveal-img">
             <img src="assets\profile.jpg" alt="Profile Image" class="profile-img">
-            <div class="data-overlay">
+            <div class="data-overlay" translate="no">
                 STATUS: CODING<br>
                 MAIN: JS_CHATBOT<br>
             </div>
@@ -254,7 +255,7 @@
                 </div>
                 <div class="sns-text-box">
                     <span class="sns-name" translate="no">GITHUB</span>
-                    <span class="sns-status">Source Code</span>
+                    <span class="sns-status" translate="no">Source Code</span>
                 </div>
             </a>
             <a href="https://discord.com/users/877104971265478676" target="_blank" rel="noopener noreferrer"
@@ -264,7 +265,7 @@
                 </div>
                 <div class="sns-text-box">
                     <span class="sns-name" translate="no">DISCORD</span>
-                    <span class="sns-status">Direct Message</span>
+                    <span class="sns-status" translate="no">Direct Message</span>
                 </div>
             </a>
             <a href="https://open.kakao.com/me/yeonggyu1110" target="_blank" rel="noopener noreferrer"
@@ -274,7 +275,7 @@
                 </div>
                 <div class="sns-text-box">
                     <span class="sns-name" translate="no">KAKAOTALK</span>
-                    <span class="sns-status">Open Profile</span>
+                    <span class="sns-status" translate="no">Open Profile</span>
                 </div>
             </a>
         </div>
@@ -286,7 +287,7 @@
                 </div>
                 <div class="sns-text-box">
                     <span class="sns-name" translate="no">INSTAGRAM</span>
-                    <span class="sns-status">Follow me</span>
+                    <span class="sns-status" translate="no">Follow me</span>
                 </div>
             </a>
             <a href="https://ch.tetr.io/u/cys1lent" target="_blank" rel="noopener noreferrer"
@@ -296,7 +297,7 @@
                 </div>
                 <div class="sns-text-box">
                     <span class="sns-name" translate="no">TETR.IO</span>
-                    <span class="sns-status">tetrio player</span>
+                    <span class="sns-status" translate="no">tetrio player</span>
                 </div>
             </a>
         </div>

--- a/projects/index.html
+++ b/projects/index.html
@@ -37,7 +37,7 @@
 
 </head>
 
-<body translate="no">
+<body>
 
     <div class="cursor-glow"></div>
     <div class="cursor-dot"></div>
@@ -54,7 +54,7 @@
 
     <header class="project-header">
 
-        <div class="marquee-wrapper" aria-hidden="true">
+        <div class="marquee-wrapper" aria-hidden="true" translate="no">
 
             <div class="marquee-track left-to-right" style="--speed: 50s;">
                 <div class="marquee-content">
@@ -172,22 +172,22 @@
         <section id="sec-chatbot" class="category-section">
             <div class="category-header reveal-text">
                 <span class="cat-num">01.</span>
-                <h3 class="cat-name" translate="yes">CHATBOT LOGIC</h3>
+                <h3 class="cat-name">CHATBOT LOGIC</h3>
                 <span class="cat-line"></span>
             </div>
 
             <div class="projects-grid">
                 <div class="project-card reveal-card delay-100">
                     <div class="card-header">
-                        <span class="project-type">C:\KakaoBot</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\KakaoBot</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">kakaoTalkBots</h3>
                         <p class="project-desc" data-translate="kakaoTalkBots" translate="yes">메신저봇 프레임워크를 이용해 초기에 제작했던
                             채팅 응답 스크립트들을 모아둔
                             저장소입니다. 효율적이지 못한 초기 코드들이 다량 포함되어 있으며, 단순 기록 및 보관을 목적으로 하고 있습니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">JavaScript</span>
                             <span class="tech-tag">Rhino</span>
                         </div>
@@ -201,8 +201,8 @@
 
                 <div class="project-card reveal-card delay-100">
                     <div class="card-header">
-                        <span class="project-type">C:\Discord.js</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Discord.js</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">DiscordBot_Examples</h3>
@@ -210,7 +210,7 @@
                             다양한
                             유틸리티 봇 예제 모음입니다. REST API 연동(고양이 이미지, 날씨, 번역)부터 데이터 가공(진법 변환, 모스부호, 아스키 아트), 그리고
                             한국어 자모 분리까지 디스코드 봇의 다채로운 활용 가능성을 탐구한 코드들을 담고 있습니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">Discord.js</span>
                             <span class="tech-tag">Node.js</span>
                             <span class="tech-tag">REST API</span>
@@ -236,15 +236,15 @@
             <div class="projects-grid">
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\Main_Archive</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Main_Archive</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">YeongGyu1110.github.io</h3>
                         <p class="project-desc" data-translate="Yeonggyu1110GithubIo" translate="yes">사이버펑크 터미널 UI 컨셉으로
                             제작된 개인 포트폴리오
                             웹사이트입니다. 바닐라 자바스크립트와 CSS 애니메이션을 활용하여 시스템 터미널과 유사한 몰입감 있는 인터페이스를 구현했습니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">Vanilla JS</span>
@@ -262,15 +262,15 @@
 
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\Class_Manager</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Class_Manager</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">class-layout</h3>
                         <p class="project-desc" data-translate="classLayout" translate="yes">사용자 정의 알고리즘을 활용한 효율적인 좌석 배치
                             및 관리 솔루션입니다. 랜덤
                             배치, 파트너 매칭, 빠른 좌석 선정 등 직관적인 UI와 기능을 제공합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">Vanilla JS</span>
@@ -288,15 +288,15 @@
 
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\Secure_Chat</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Secure_Chat</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">prism-chat</h3>
                         <p class="project-desc" data-translate="prismChat" translate="yes">중앙 서버 없이 WebRTC와 P2P 기술을 활용해
                             구축된 보안 강화형 1:1
                             메시징 플랫폼입니다. 실시간 데이터 채널을 통한 직접 연결로 데이터 보안과 익명성을 보장합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">WebRTC</span>
@@ -316,15 +316,15 @@
 
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\Algorithm?</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Algorithm?</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">magic-age-guesser</h3>
                         <p class="project-desc" data-translate="magicAgeGuesser" translate="yes">논리적인 5가지 질문과 수리적 알고리즘을
                             결합하여 사용자의 연령을
                             추론하는 웹 애플리케이션입니다. 간단한 인터랙션을 통해 알고리즘의 예측 정확도를 시각적으로 보여줍니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">Vanilla JS</span>
@@ -342,15 +342,15 @@
 
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\Visual_FX</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Visual_FX</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">Horror-Glitch</h3>
                         <p class="project-desc" data-translate="horrorGlitch" translate="yes">CSS와 JavaScript를 조합하여 시각적인
                             공포 효과와 글리치,
                             점프스퀘어 연출을 실험한 프로젝트입니다. 웹 환경에서 동적인 애니메이션과 스크립트를 통해 사용자에게 심리적 긴장감을 주는 기법을 탐구합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">Vanilla JS</span>
@@ -368,15 +368,15 @@
 
                 <div class="project-card offline-card reveal-card delay-200">
                     <div class="card-header">
-                        <span class="project-type">C:\Bot_Maker</span>
-                        <span class="project-status">[ SYS_OFFLINE ]</span>
+                        <span class="project-type" translate="no">C:\Bot_Maker</span>
+                        <span class="project-status" translate="no">[ SYS_OFFLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">make-your-chatBot</h3>
                         <p class="project-desc" data-translate="makeYourChatBot" translate="yes">웹 브라우저 상에서 직접 채팅 반응형 봇을
                             설계하고 테스트할 수 있는
                             개발 도구입니다. 사용자 정의 스크립트가 실제 환경에서 어떻게 동작하는지 실시간으로 시뮬레이션합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">Vanilla JS</span>
@@ -391,15 +391,15 @@
 
                 <div class="project-card offline-card reveal-card delay-200">
                     <div class="card-header">
-                        <span class="project-type">C:\Web_Terminal</span>
-                        <span class="project-status">[ SYS_OFFLINE ]</span>
+                        <span class="project-type" translate="no">C:\Web_Terminal</span>
+                        <span class="project-status" translate="no">[ SYS_OFFLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">web-cmd</h3>
                         <p class="project-desc" data-translate="webCMD" translate="yes">웹 기반 인터페이스에서 챗봇 로직을 제작하고 이를 로컬
                             환경에서 실행할 수 있도록
                             연동하는 시스템입니다. 터미널 환경의 명령어를 웹으로 이식하여 명령 체계를 시각화했습니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                             <span class="tech-tag">Vanilla JS</span>
@@ -424,8 +424,8 @@
 
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\HTML-CSS</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\HTML-CSS</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">learn-html-css</h3>
@@ -433,7 +433,7 @@
                             CSS3의 구조적 설계
                             방식을
                             학습한 기록입니다. 반응형 레이아웃과 웹 표준을 준수하는 시맨틱 마크업을 중점적으로 다룹니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">HTML5</span>
                             <span class="tech-tag">CSS3</span>
                         </div>
@@ -447,8 +447,8 @@
 
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\react</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\react</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">learn-react</h3>
@@ -456,7 +456,7 @@
                             아키텍처를 이해하기 위한
                             React 학습
                             과정입니다. 가상 DOM의 효율성과 상태 관리 라이브러리의 활용 방식을 탐구합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">REACT</span>
                             <span class="tech-tag">JS</span>
                         </div>
@@ -470,15 +470,15 @@
 
                 <div class="project-card offline-card reveal-card delay-200">
                     <div class="card-header">
-                        <span class="project-type">C:\JavaScript</span>
-                        <span class="project-status">[ SYS_OFFLINE ]</span>
+                        <span class="project-type" translate="no">C:\JavaScript</span>
+                        <span class="project-status" translate="no">[ SYS_OFFLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">learn-javascript</h3>
                         <p class="project-desc" data-translate="learnJavascript" translate="yes">자바스크립트의 핵심 개념부터 ES6+ 최신
                             문법까지 깊이 있게 다루는
                             학습 저장소입니다. 실행 컨텍스트와 프로토타입 등 언어의 내부 작동 원리를 분석합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">JavaScript</span>
                             <span class="tech-tag">ES6</span>
                         </div>
@@ -500,8 +500,8 @@
             <div class="projects-grid">
                 <div class="project-card reveal-card">
                     <div class="card-header">
-                        <span class="project-type">C:\Discord.js</span>
-                        <span class="project-status">[ SYS_ONLINE ]</span>
+                        <span class="project-type" translate="no">C:\Discord.js</span>
+                        <span class="project-status" translate="no">[ SYS_ONLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">discord.js-sendbox</h3>
@@ -509,7 +509,7 @@
                             테스트하고 실험하는 전용
                             샌드박스 환경입니다. 비동기 자바스크립트 핸들링과 봇 상호작용의 핵심 원리를 학습합니다.
                         </p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">Discord.js</span>
                             <span class="tech-tag">Node.js</span>
                             <span class="tech-tag">JavaScript</span>
@@ -524,14 +524,14 @@
 
                 <div class="project-card offline-card reveal-card delay-200">
                     <div class="card-header">
-                        <span class="project-type">C:\JavaScript_ES6</span>
-                        <span class="project-status">[ SYS_OFFLINE ]</span>
+                        <span class="project-type" translate="no">C:\JavaScript_ES6</span>
+                        <span class="project-status" translate="no">[ SYS_OFFLINE ]</span>
                     </div>
                     <div class="project-content">
                         <h3 class="project-title">javascript-sendbox</h3>
                         <p class="project-desc" data-translate="javascriptSendbox" translate="yes">자바스크립트의 언어적 특성을 깊이 있게
                             탐구하는 실험실입니다. 참조 데이터 타입의 동작 원리, 깊은/얕은 복사, 그리고 ES6+ 최신 문법을 실제 코드로 구현하며 언어의 심층부를 분석합니다.</p>
-                        <div class="tech-stack">
+                        <div class="tech-stack" translate="no">
                             <span class="tech-tag">JavaScript</span>
                             <span class="tech-tag">ES6+</span>
                             <span class="tech-tag">Algorithm</span>
@@ -571,17 +571,18 @@
                     <div class="archive-content ">
                         <div class="archive-text-box">
                             <span class="archive-prompt">
-                                <span class="prompt-path">PS C:\Users\YeongGyu\Projects</span><span
+                                <span class="prompt-path" translate="no">PS C:\Users\YeongGyu\Projects</span><span
                                     class="prompt-arrow">></span>
                             </span>
-                            <span class="archive-inner-title">cd ..<span class="cursor-blink">_</span></span>
+                            <span class="archive-inner-title" translate="no">cd ..<span
+                                    class="cursor-blink">_</span></span>
                             <span class="archive-inner-sub" data-translate="ProjectArchiveInnerSub" translate="yes">클릭하면
                                 전체 프로젝트 목록을 닫고 홈 화면으로 돌아갑니다.</span>
                         </div>
 
                         <div class="archive-action">
                             <div class="action-btn">
-                                <span class="btn-text">RETURN</span>
+                                <span class="btn-text" translate="no">RETURN</span>
                                 <div class="action-icon">
                                     <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                                         <path d="M20 4V11C20 13.2091 18.2091 15 16 15H4" stroke="currentColor"
@@ -615,7 +616,7 @@
     <aside id="profile-sidebar" class="profile-sidebar">
         <div class="sidebar-header">
             <span class="sidebar-title">// DEV_PROFILE</span>
-            <button id="sidebar-close-btn" class="sidebar-close">[X]</button>
+            <button id="sidebar-close-btn" class="sidebar-close" translate="no">[X]</button>
         </div>
 
         <div class="sidebar-content">
@@ -632,7 +633,7 @@
             <div class="sidebar-section">
                 <div class="section-title">
                     <span data-translate="sidebarActivityTitle">> 깃허브 활동 로그</span>
-                    <span class="blink">_</span>
+                    <span class="blink" translate="no">_</span>
                 </div>
                 <p class="section-desc" data-translate="sidebarActivityDesc">// 최근 3개월의 기여 데이터</p>
 
@@ -650,7 +651,7 @@
             <div class="active-users-block">
                 <span data-translate="sidebarActiveUsers">// 실시간 접속자 수:</span>
                 <span id="active-nodes" class="blink"
-                    style="color: var(--accent-color); font-weight: bold; margin-left: 5px;">1</span>
+                    style="color: var(--accent-color); font-weight: bold; margin-left: 5px;" translate="no">1</span>
             </div>
         </div>
     </aside>

--- a/projects/index.html
+++ b/projects/index.html
@@ -619,41 +619,37 @@
         </div>
 
         <div class="sidebar-content">
-            <!-- 프로필 섹션 -->
             <div class="profile-info-block">
                 <div class="profile-avatar">
                     <img src="https://github.com/yeonggyu1110.png" alt="Profile">
                 </div>
                 <div class="profile-text">
-                    <h3 class="profile-name">YeongGyu1110</h3>
-                    <p class="profile-status">[ SYS_ADMIN ]</p>
+                    <h3 class="profile-name" translate="no">YeongGyu1110</h3>
+                    <p class="profile-status" data-translate="sidebarStatus">[ 메인 개발자 ]</p>
                 </div>
             </div>
 
-            <!-- 커스텀 깃허브 3개월 달력 섹션 -->
             <div class="sidebar-section">
                 <div class="section-title">
-                    <span>> ACTIVITY_MATRIX_SCANNER</span>
+                    <span data-translate="sidebarActivityTitle">> 깃허브 활동 로그</span>
                     <span class="blink">_</span>
                 </div>
-                <p class="section-desc">// RECENT_3_MONTHS_DATA_STREAM</p>
+                <p class="section-desc" data-translate="sidebarActivityDesc">// 최근 3개월의 기여 데이터</p>
 
-                <!-- JS가 달력 3개를 주입할 컨테이너 -->
                 <div id="cyber-calendar-container" class="calendar-wrapper">
-                    <!-- Loading Text -->
-                    <div class="loading-matrix">FETCHING_GITHUB_DATA...</div>
+                    <div class="loading-matrix" data-translate="sidebarLoading">데이터를 동기화 중입니다...</div>
                 </div>
             </div>
         </div>
 
-        <!-- 사이드바 푸터 (접속자 수) -->
         <div class="sidebar-footer">
             <div class="status-indicator">
                 <div class="status-dot"></div>
-                <span class="status-text">SYSTEM_ONLINE</span>
+                <span class="status-text" data-translate="sidebarSystemOnline">시스템 정상 작동 중</span>
             </div>
             <div class="active-users-block">
-                // ACTIVE_NODES: <span id="active-nodes" class="blink"
+                <span data-translate="sidebarActiveUsers">// 실시간 접속자 수:</span>
+                <span id="active-nodes" class="blink"
                     style="color: var(--accent-color); font-weight: bold; margin-left: 5px;">1</span>
             </div>
         </div>

--- a/script/script.js
+++ b/script/script.js
@@ -1,5 +1,4 @@
 const glow = document.querySelector('.cursor-glow');
-const dot = document.querySelector('.cursor-dot');
 
 let mouseX = window.innerWidth / 2;
 let mouseY = window.innerHeight / 2;
@@ -99,6 +98,14 @@ const translations = {
     gallerySub: {
         ko: "최신 기술 트렌드와 현장의 인사이트를 수집합니다.",
         en: "Gathering intelligence from the tech frontier."
+    },
+    galleryAlt1: {
+        ko: "2025년 12월 6일. DEVFEST INCHEON 2025 행사에서 '2026년: LLM 다음의 이야기' 세션을 기록한 사진",
+        en: "December 6, 2025. A photo recording the session '2026: Story after LLM' at DEVFEST INCHEON 2025."
+    },
+    galleryAlt2: {
+        ko: "2026년 1월 30일. AI SEOUL 2026 행사에 갔다온 걸 기록한 사진",
+        en: "January 30, 2026. A photo recording the visit to AI SEOUL 2026."
     },
     archiveSub: {
         ko: "구현된 모든 로직과 웹 인터페이스 아카이브를 탐색합니다.",
@@ -201,11 +208,26 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function updateContent(lang) {
         const elements = document.querySelectorAll('[data-translate]');
-
         elements.forEach(el => {
             const key = el.getAttribute('data-translate');
             if (translations[key] && translations[key][lang]) {
                 el.innerHTML = translations[key][lang];
+            }
+        });
+
+        const altElements = document.querySelectorAll('[data-translate-alt]');
+        altElements.forEach(el => {
+            const key = el.getAttribute('data-translate-alt');
+            if (translations[key] && translations[key][lang]) {
+                el.setAttribute('alt', translations[key][lang]);
+            }
+        });
+
+        const titleElements = document.querySelectorAll('[data-translate-title]');
+        titleElements.forEach(el => {
+            const key = el.getAttribute('data-translate-title');
+            if (translations[key] && translations[key][lang]) {
+                el.setAttribute('title', translations[key][lang]);
             }
         });
 

--- a/script/script.js
+++ b/script/script.js
@@ -190,7 +190,14 @@ const translations = {
     snsSub: {
         ko: "협업과 소통을 위한 연결 채널",
         en: "Open for collaboration."
-    }
+    },
+    sidebarStatus: { ko: "[ 메인 개발자 ]", en: "[ LEAD DEVELOPER ]" },
+    sidebarActivityTitle: { ko: "> 깃허브 활동 로그", en: "> GITHUB_ACTIVITY_LOG" },
+    sidebarActivityDesc: { ko: "// 최근 3개월의 기여 데이터", en: "// LAST_3_MONTHS_CONTRIBUTION" },
+    sidebarLoading: { ko: "데이터를 동기화 중...", en: "SYNCING_GITHUB_DATA..." },
+    sidebarActiveUsers: { ko: "// 실시간 접속자 수:", en: "// ACTIVE_SESSIONS:" },
+    sidebarSystemOnline: { ko: "시스템: 온라인", en: "SYSTEM_ONLINE" }
+
 };
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
 - alt와 title도 번역되도록 번역 로직을 개선한다.
 - aside 내부의 텍스트를 더 명확한 정보성 텍스트로 바꾼다.
 - 고유명사, 터미널 경로, 상태 메시지 등 장식용 텍스트에 translate="no" 속성을 붙혀 번역되지 않도록 한다.